### PR TITLE
Bump the maven-dependencies group with 3 updates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.0"
+agp = "8.5.1"
 kotlin = "2.0.0"
 nav = "2.7.7"
 appcenter = "5.0.4"


### PR DESCRIPTION
Bumps the maven-dependencies group with 3 updates: com.android.tools.build:apksig, com.android.library and com.android.application.


Updates `com.android.tools.build:apksig` from 8.5.0 to 8.5.1

Updates `com.android.library` from 8.5.0 to 8.5.1

Updates `com.android.application` from 8.5.0 to 8.5.1

Updates `com.android.library` from 8.5.0 to 8.5.1

Updates `com.android.application` from 8.5.0 to 8.5.1

---
updated-dependencies:
- dependency-name: com.android.tools.build:apksig dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven-dependencies
- dependency-name: com.android.library dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven-dependencies
- dependency-name: com.android.application dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven-dependencies
- dependency-name: com.android.library dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven-dependencies
- dependency-name: com.android.application dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven-dependencies ...